### PR TITLE
gitignore.jj2: Move extra block to end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # moban hashes
 .moban.hashes
 
-
 # Extra rules from https://github.com/github/gitignore/
 # Python rules
 # Byte-compiled / optimized / DLL files

--- a/templates/gitignore.jj2
+++ b/templates/gitignore.jj2
@@ -19,9 +19,6 @@
 # moban hashes
 .moban.hashes
 
-{%block extra%}
-{%endblock%}
-
 # Extra rules from https://github.com/github/gitignore/
 {% if gitignore_language %}
 # {{ gitignore_language }} rules
@@ -40,3 +37,6 @@
 # {{ ruleset }} rules
 {% include 'gitignore/Global/' + ruleset + '.gitignore' %}
 {% endfor %}
+
+{%block extra%}
+{%endblock%}


### PR DESCRIPTION
The extra block needs to override other rules
which may have been imported.