### PR TITLE
remove plugin name

### DIFF
--- a/plugins/github.py
+++ b/plugins/github.py
@@ -11,7 +11,7 @@ PULL = "pull"
 ISSUES = "issues"
 
 
-@JinjaFilter('github_expand')
+@JinjaFilter()
 def github_expand(line, name, organisation):
     result = re.match(ISSUE, line)
     if result:

--- a/plugins/text.py
+++ b/plugins/text.py
@@ -2,7 +2,7 @@ import re
 from moban.extensions import JinjaFilter
 
 
-@JinjaFilter('split_length')
+@JinjaFilter()
 def split_length(input_line, length):
     start = 0
     limit = length


### PR DESCRIPTION
The decorator doesnt need to be given the name of the wrapped
function.