### PR TITLE
[WIP] setup.py.jj2: Allow comments in requirements.txt

### DIFF
--- a/templates/setup.py.jj2
+++ b/templates/setup.py.jj2
@@ -111,7 +111,7 @@ if python_implementation == "PyPy":
 {%- endmacro %}
 INSTALL_REQUIRES = [
 {% for dependency in dependencies: %}
-  {% if ';' not in dependency: %}
+  {% if ';' not in dependency and not dependency.startswith('#'): %}
     '{{dependency}}',
   {%   endif %}
 {% endfor %}


### PR DESCRIPTION
Closes https://github.com/moremoban/pypi-mobans/issues/37

Possible scenarios:
* A standalone comment
* An inline comment
* Tackle '#' also when requirement is a remote repo, _e.g._ `git+https://gitlab.com/coala/PyPrint#egg=pyprint # comment`.
* Handle the same in `EXTRA_REQUIRES` also.