### PR TITLE
setup.py.jj2: Allow comments in requirements.txt

### DIFF
--- a/.moban.dt/local-README.rst.jj2
+++ b/.moban.dt/local-README.rst.jj2
@@ -28,6 +28,10 @@ setup.py
    - automatically do git release while uploading to pypi
 
 3. configured to build universial wheels by default
+
+4. comes with a feature of removing comments from requirements.txt while loading
+into setup.py
+
 {% endblock %}
 
 {% block bottom_block %}

--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,10 @@ setup.py
 
 3. configured to build universial wheels by default
 
+4. comes with a feature of removing comments from requirements.txt while loading
+into setup.py
+
+
 Installation
 ================================================================================
 

--- a/templates/setup.py.jj2
+++ b/templates/setup.py.jj2
@@ -113,7 +113,20 @@ if python_implementation == "PyPy":
 INSTALL_REQUIRES = [
 {% for dependency in dependencies: %}
   {% if ';' not in dependency and not dependency.startswith('#'): %}
+    {% if '#egg=' in dependency: %}
+      {% set dependency = dependency.split('#egg=') %}
+      {% set repo_link, egg_name = dependency[0], dependency[1] %}
+      {% set repo_link = repo_link.strip() %}
+      {% if '#' in egg_name: %}
+        {% set egg_name = egg_name.split('#')[0].strip() %}
+      {% endif %}
+    '{{[repo_link, egg_name] | join('#egg=')}}',
+    {% elif '#' in dependency: %}
+      {% set dependency = dependency.split('#')[0].strip() %}
     '{{dependency}}',
+    {% else %}
+    '{{dependency}}',
+    {% endif %}
   {%   endif %}
 {% endfor %}
 ]


### PR DESCRIPTION
Closes https://github.com/moremoban/pypi-mobans/issues/37

https://github.com/moremoban/pypi-mobans/pull/51 addresses a fix for a standalone comment.
In this PR, the following are handled - 

* An inline comment
* Tackle '#' also when requirement is a remote repo, _e.g._, `git+https://gitlab.com/coala/PyPrint#egg=pyprint # comment` 