### PR TITLE
setup.py: Add codecs and locale hacks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,3 +9,4 @@ First release
 
 #. versioning is applied
 #. Pipfile included
+#. codec and locale hacks added

--- a/changelog.yml
+++ b/changelog.yml
@@ -6,6 +6,7 @@ releases:
     details:
     - versioning is applied
     - Pipfile included
+    - codec and locale hacks added
   date: 05.11.2018
   version: 0.0.1
 

--- a/templates/setup.py.jj2
+++ b/templates/setup.py.jj2
@@ -25,7 +25,29 @@ from platform import python_implementation
 {%block compat_block%}
 PY2 = sys.version_info[0] == 2
 PY26 = PY2 and sys.version_info[1] < 7
+PY33 = sys.version_info < (3, 4)
 {%endblock%}
+
+# Work around mbcs bug in distutils.
+# http://bugs.python.org/issue10945
+# This work around is only if a project supports Python < 3.4
+{% if PY33 %}
+try:
+    codecs.lookup('mbcs')
+except LookupError:
+    ascii = codecs.lookup('ascii')
+    func = lambda name, enc=ascii: {True: enc}.get(name=='mbcs')
+    codecs.register(func)
+{% endif %}
+
+# Work around for locale not being set
+try:
+    lc = locale.getlocale()
+    pf = platform.system()
+    if pf != 'Windows' and lc == (None, None):
+        locale.setlocale(locale.LC_ALL, 'C.UTF-8')
+except (ValueError, UnicodeError, locale.Error):
+    locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
 
 NAME = '{{name}}'
 AUTHOR = '{{author}}'


### PR DESCRIPTION
codec and locale hacks have been added to avoid
breakages in setup.py

Closes https://github.com/moremoban/pypi-mobans/issues/46