### PR TITLE
Add dev-packages section in pipfile; new implementation

### DIFF
--- a/templates/Pipfile.jj2
+++ b/templates/Pipfile.jj2
@@ -8,9 +8,25 @@ python_version= '3.6'
 
 [packages]
 {% for dependency in dependencies: %}
-  {% if '=' in dependency %}
+  {% if ('=' in dependency) or ('>' in dependency) or ('<' in dependency) %}
     {{dependency}}
   {% else %}
     {{dependency}} = "*"
   {% endif %}
 {% endfor %}
+
+[dev-packages]
+nose = "*"
+mock = "*"
+codecov = "*"
+coverage = "*"
+flake8 = "*"
+{% if dev_dependencies is defined %}
+  {% for dependency in dev_dependencies: %}
+    {% if ('=' in dependency) or ('>' in dependency) or ('<' in dependency) %}
+      {{dependency}}
+    {% else %}
+      {{dependency}} = "*"
+    {% endif %}
+  {% endfor %}
+{% endif %}


### PR DESCRIPTION
Closes #58.

Added support for only "greater than version" or "less than version" dependencies.

Also, now the YAML file can have a `dev_dependencies` list just like `dependencies`, and it will add them to `dev-packages` section in the pipfile, along with the ones already in the template.