### PR TITLE
:hammer: improve min_requirements template

### DIFF
--- a/templates/min_requirements.txt.jj2
+++ b/templates/min_requirements.txt.jj2
@@ -1,7 +1,14 @@
 {% for dependency in dependencies: %}
-{%     if ';' in dependency: %}
-{{dependency.split(';')[0].replace('>=', '==').replace('>', '==') + ';' + dependency.split(';')[1]}}
-{%     else: %}
-{{dependency.replace('>=', '==').replace('>', '==')}}
-{%     endif %}
+{%   if ';' in dependency %}
+{%     set dependency, marker = dependency.split(';') %}
+{%   else %}
+{%     set marker = None %}
+{%   endif %}
+{%   set dependency = dependency.split(',')[0] %}
+{%   set dependency = dependency.replace('>=', '==').replace('>', '==') %}
+{%   if marker %}
+{{dependency + ';' + marker }}
+{%   else: %}
+{{dependency}}
+{%   endif %}
 {% endfor %}


### PR DESCRIPTION
Discard extra requirements when a dependency contains multiple
constraints with a comma.
Refactor also to simplify and improve style.

Closes https://github.com/moremoban/pypi-mobans/issues/88