### PR TITLE
:construction: .gitattributes merge strategies

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Include changes from both sides
+changelog.yml merge=union
+# Include regenerated files as-is using binary merge driver
+CHANGELOG.rst merge=binary


### PR DESCRIPTION
Use union for changelog yaml, and
use binary for generaged CHANGELOG.rst.

Related to https://github.com/moremoban/pypi-mobans/issues/97