### PR TITLE
:bug: temporary fix for #105

### DIFF
--- a/templates/lint.script.jj2
+++ b/templates/lint.script.jj2
@@ -1,1 +1,2 @@
+pip install flake8
 flake8 . --exclude=.moban.d,docs {%block flake8_options%}--builtins=unicode,xrange,long{%endblock%}


### PR DESCRIPTION
add flake8 installation back in lint.sh if custom command is `make lint`.