### PR TITLE
run single job lint and moban first. because if they fail, …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ python:
   - 2.7
 
 stages:
-  - test
   - lint
   - moban
+  - test
 
 .disable_global: &disable_global
   addons: false

--- a/templates/travis.yml.jj2
+++ b/templates/travis.yml.jj2
@@ -32,13 +32,13 @@ python:
 
 {% block stages %}
 stages:
-  - test
 {% if lint_command != False %}
   - lint
 {% endif %}
 {% if moban_command != False %}
   - moban
 {% endif %}
+  - test
 
 {% endblock %}
 .disable_global: &disable_global


### PR DESCRIPTION
…you need to run them again any way. so it would cost the world less resource(cpu, memory and travis)